### PR TITLE
HTML comments in Markdown, email link variants

### DIFF
--- a/lib/markdown/markdown.tcl
+++ b/lib/markdown/markdown.tcl
@@ -553,10 +553,8 @@ namespace eval Markdown {
                             append result "<a href=\"$link\">$link</a>"
                         } else {
                             set mailto_prefix "mailto:"
-                            if {[regexp "^$mailto_prefix" $email]} {
-                                set mailto $email
-                                set email [string range $email [string length $mailto_prefix] end]
-                            } else {
+                            if {![regexp "^${mailto_prefix}(.*)" $email mailto email]} {
+                                # $email does not contain the prefix "mailto:".
                                 set mailto "mailto:$email"
                             }
                             append result "<a href=\"$mailto\">$email</a>"


### PR DESCRIPTION
Features implemented:
- Respect (i.e., pass through unprocessed) HTML comments in Markdown.
- Process email links of the form `<mailto:contact@example.com>` _and_ `<contact@example.com>`.

Both changes are to match the behavior of [Markdown.pl](http://daringfireball.net/projects/markdown/).
