### PR TITLE
Workaround for Itcl4 bug in info heritage command

### DIFF
--- a/lib/testing/testobj.tcl
+++ b/lib/testing/testobj.tcl
@@ -282,7 +282,7 @@ namespace eval Testing {
         }
 
         private method setup {{method setup}} {
-            foreach {class} [lreverse [$this info heritage]] {
+            foreach {class} [lreverse [uplevel #0 [list $this] info heritage]] {
                 if {![catch { lassign [$this info function ${class}::${method} \
                         -protection -type] protection type }]} \
                 {
@@ -294,7 +294,7 @@ namespace eval Testing {
         }
 
         private method teardown {{method teardown}} {
-            foreach {class} [$this info heritage] {
+            foreach {class} [uplevel #0 [list $this] info heritage] {
                 if {![catch { lassign [$this info function ${class}::${method} \
                         -protection -type] protection type }]} \
                 {


### PR DESCRIPTION
Workaround for ITcl 4 bug in `info heritage`
